### PR TITLE
Changed period to colon before code snippet for consistency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -152,7 +152,7 @@ The `fs.readFile` method is provided by node, is asynchronous and happens to tak
 
 Think of the restaurant example at the beginning of this tutorial. At many restaurants you get a number to put on your table while you wait for your food. These are a lot like callbacks. They tell the server what to do after your cheeseburger is done.
 
-Let's put our `console.log` statement into a function and pass it in as a callback.
+Let's put our `console.log` statement into a function and pass it in as a callback:
 
 ```js
 var fs = require('fs')


### PR DESCRIPTION
All other sentences leading into code snippets end in a colon. This one ended in a period.

Other code snippets: 
![image](https://cloud.githubusercontent.com/assets/7017045/5593656/a1e98716-91d2-11e4-8cbc-b705cb2e4590.png)

This code snippet: 
![image](https://cloud.githubusercontent.com/assets/7017045/5593657/b09e2e24-91d2-11e4-850a-ae5f58fcd2e6.png)

Change: 
![image](https://cloud.githubusercontent.com/assets/7017045/5593658/bebcc9d4-91d2-11e4-9f5a-23f70f10cbfa.png)

Thanks for the great material!

