### PR TITLE
fix typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -481,7 +481,7 @@ module.exports = 1
 
 By default node tries to load `module/index.js` when you `require('module')`, any other file name won't work unless you set the `main` field of `package.json` to point to it.
 
-Put both of those files in a folder called `number-one` (the `id` in `package.json` must match the folder name) and you'll have a working node module.
+Put both of those files in a folder called `number-one` (the `name` in `package.json` must match the folder name) and you'll have a working node module.
 
 Calling the function `require('number-one')` returns the value of whatever `module.exports` is set to inside the module:
 


### PR DESCRIPTION
I consult the info about package.json and find that there is no property named __id__, and i think you mean __id__ for __name__, so i fix this.